### PR TITLE
Fix performance bottleneck in XmlUtil

### DIFF
--- a/MapleLib/WzLib/Util/XmlUtil.cs
+++ b/MapleLib/WzLib/Util/XmlUtil.cs
@@ -30,7 +30,7 @@ namespace MapleLib.WzLib.Util
 
 		public static string SanitizeText(string text)
 		{
-			string fixedText = "";
+			StringBuilder fixedText = new StringBuilder("");
 			bool charFixed;
 			for (int i = 0; i < text.Length; i++)
 			{
@@ -40,17 +40,17 @@ namespace MapleLib.WzLib.Util
 
 					if (text[i] == specialCharacters[k])
 					{
-						fixedText += replacementStrings[k];
+						fixedText.Append(replacementStrings[k]);
 						charFixed = true;
 						break;
 					}
 				}
 				if (!charFixed)
 				{
-					fixedText += text[i];
+					fixedText.Append(text[i]);
 				}
 			}
-			return fixedText;
+			return fixedText.ToString();
 		}
 
 		public static string OpenNamedTag(string tag, string name, bool finish)


### PR DESCRIPTION
Quick fix to a method in XmlUtil that was causing severe performance bottlenecking.

This speeds up XML exporting by a ridiculous amount; most noticeable on modern versions that have huge amounts of Spine/JSON data in string nodes, difference isn't as dramatic on lower versions but still noticeable.

In testing I got something like 20 to 40 times speedup when exporting `Map.wz\Effect2.img` from v206.