### PR TITLE
Fix saving wz from one custom key to another custom key

### DIFF
--- a/MapleLib/WzLib/WzDirectory.cs
+++ b/MapleLib/WzLib/WzDirectory.cs
@@ -344,9 +344,10 @@ namespace MapleLib.WzLib
 
             foreach (WzImage img in images)
             {
-                if (useCustomIv ||// everything needs to be re-written when a custom IV is used.
-                    !bIsWzUserKeyDefault || //  everything needs to be re-written when a custom UserKey is used too
-                    img.bIsImageChanged) // or when an image is changed
+                // If useCustomIv or !bIsWzUserKeyDefault is true, then the image must be considered changed
+                // Why do I have to change img.bIsImageChanged? Because if it's not changed, it won't be re-written with custom IV and UserKey.
+                img.bIsImageChanged = useCustomIv || !bIsWzUserKeyDefault;
+                if (img.bIsImageChanged)
                 {
                     using (MemoryStream memStream = new MemoryStream())
                     {


### PR DESCRIPTION
when saving a WZ file with custom encryption to another custom encryption, the saved file ends up corrupted.
I know there is a check in SaveForm:

https://github.com/lastbattle/Harepacker-resurrected/blob/6979ebcb21687bc7ac1325c0a2785af1c96ae5ef/HaRepacker/GUI/SaveForm.cs#L163-L166
https://github.com/lastbattle/Harepacker-resurrected/blob/6979ebcb21687bc7ac1325c0a2785af1c96ae5ef/HaRepacker/GUI/SaveForm.cs#L244-L254

this check only works when the target WzMapleVersion is different from the original, (like going from BMS to GMS), but it doesn't work if both the original and target versions are CUSTOM.