### PR TITLE
Fix WzRawDataProperty

### DIFF
--- a/MapleLib/WzLib/WzProperties/WzRawDataProperty.cs
+++ b/MapleLib/WzLib/WzProperties/WzRawDataProperty.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace MapleLib.WzLib.WzProperties
 {
-    public class WzRawDataProperty : WzExtended
+    public class WzRawDataProperty : WzExtended, IPropertyContainer
     {
 
         #region Fields
@@ -13,9 +13,11 @@ namespace MapleLib.WzLib.WzProperties
         internal WzObject _parent;
         internal WzBinaryReader _wzReader;
 
-        internal long _offset;
+        internal byte _type;
+        internal long _rawDataOffset; // 
         internal int _length;
         internal byte[] _bytes;
+        internal WzPropertyCollection properties;
         #endregion
 
         /// <summary>
@@ -23,37 +25,28 @@ namespace MapleLib.WzLib.WzProperties
         /// </summary>
         /// <param name="name"></param>
         /// <param name="reader"></param>
-        /// <param name="parseNow"></param>
-        public WzRawDataProperty(string name, WzBinaryReader reader, bool parseNow)
+        /// <param name="type"></param>
+        public WzRawDataProperty(string name, WzBinaryReader reader, byte type)
         {
             this._name = name;
             this._wzReader = reader;
-
-            this._wzReader.BaseStream.Position++;
-            this._length = reader.ReadInt32();
-            this._offset = reader.BaseStream.Position;
-            if (parseNow)
-                GetBytes(true);
-            else
-                this._wzReader.BaseStream.Position += _length;
-        }
-
-        /// <summary>
-        /// Constructor copy
-        /// </summary>
-        /// <param name="copy"></param>
-        private WzRawDataProperty(WzRawDataProperty copy)
-        {
-            this._name = copy._name;
-            this._bytes = new byte[copy._length];
-            copy.GetBytes(false).CopyTo(_bytes, 0);
-            this._length = copy._length;
+            this._type = type;
+            this.properties = new WzPropertyCollection(this);
         }
 
         #region Inherited Members
         public override WzImageProperty DeepClone()
         {
-            return new WzRawDataProperty(this);
+            var clone = new WzRawDataProperty(_name, null, _type);
+            foreach (WzImageProperty prop in properties)
+            {
+                clone.AddProperty(prop.DeepClone());
+            }
+            clone._length = _length;
+            clone._bytes = new byte[_length]; 
+            GetBytes(false).CopyTo(clone._bytes, 0);
+
+            return clone;
         }
 
         public override object WzValue => GetBytes(false);
@@ -78,13 +71,24 @@ namespace MapleLib.WzLib.WzProperties
 
         public override string Name { get =>  _name; set => this._name = value; }
 
+        public override WzPropertyCollection WzProperties => properties;
+
         public override void WriteValue(WzBinaryWriter writer)
         {
             var data = GetBytes(false);
             writer.WriteStringValue(RAW_DATA_HEADER, WzImage.WzImageHeaderByte_WithoutOffset,
                 WzImage.WzImageHeaderByte_WithOffset);
-            writer.Write((byte)0);
-            writer.Write(data.Length);
+            writer.Write(_type);
+            if (properties.Count > 0)
+            {
+                writer.Write((byte)1);
+                WritePropertyList(writer, properties);
+            }
+            else
+            {
+                writer.Write((byte)0);
+            }
+            writer.WriteCompressedInt(data.Length);
             writer.Write(data);
         }
 
@@ -104,6 +108,16 @@ namespace MapleLib.WzLib.WzProperties
         }
         #endregion
 
+        internal void Parse(bool parseNow)
+        {
+            _length = _wzReader.ReadCompressedInt();
+            _rawDataOffset = _wzReader.BaseStream.Position;
+            if (parseNow)
+                GetBytes(true);
+            else
+                _wzReader.BaseStream.Position = _rawDataOffset + _length;
+        }
+
         public byte[] GetBytes(bool saveInMemory)
         {
             if (this._bytes != null) // check in-memory
@@ -114,7 +128,7 @@ namespace MapleLib.WzLib.WzProperties
 
             // read if none
             var currentPos = _wzReader.BaseStream.Position;
-            this._wzReader.BaseStream.Position = _offset;
+            this._wzReader.BaseStream.Position = _rawDataOffset;
             this._bytes = _wzReader.ReadBytes(_length);
             this._wzReader.BaseStream.Position = currentPos;
             if (saveInMemory)
@@ -127,6 +141,54 @@ namespace MapleLib.WzLib.WzProperties
                 this._bytes = null;
                 return ret_bytes;
             }
+        }
+
+        /// <summary>
+        /// Adds a property to the property list of this property
+        /// </summary>
+        /// <param name="prop">The property to add</param>
+        public void AddProperty(WzImageProperty prop)
+        {
+            prop.Parent = this;
+            properties.Add(prop);
+        }
+
+        public void AddProperties(WzPropertyCollection props)
+        {
+            foreach (WzImageProperty prop in props)
+            {
+                AddProperty(prop);
+            }
+        }
+
+        /// <summary>
+        /// Remove a property by its name
+        /// </summary>
+        /// <param name="name">Name of Property</param>
+        public void RemoveProperty(string propertyName)
+        {
+            WzImageProperty prop = this[propertyName];
+            if (prop != null) {
+                RemoveProperty(prop);
+            }
+        }
+
+        /// <summary>
+        /// Remove a property
+        /// </summary>
+        public void RemoveProperty(WzImageProperty prop)
+        {
+            prop.Parent = null;
+            properties.Remove(prop);
+        }
+
+        /// <summary>
+        /// Clears the list of properties
+        /// </summary>
+        public void ClearProperties()
+        {
+            foreach (WzImageProperty prop in properties) prop.Parent = null;
+            properties.Clear();
         }
     }
 }


### PR DESCRIPTION
Since GMS 255, the RawData property’s structure has been updated to support sub-properties, just like the Canvas property.