### PR TITLE
Fix WzRawDataProperty - WriteValue / Dispose

### DIFF
--- a/MapleLib/WzLib/WzProperties/WzRawDataProperty.cs
+++ b/MapleLib/WzLib/WzProperties/WzRawDataProperty.cs
@@ -79,14 +79,17 @@ namespace MapleLib.WzLib.WzProperties
             writer.WriteStringValue(RAW_DATA_HEADER, WzImage.WzImageHeaderByte_WithoutOffset,
                 WzImage.WzImageHeaderByte_WithOffset);
             writer.Write(_type);
-            if (properties.Count > 0)
+            if (_type == 1)
             {
-                writer.Write((byte)1);
-                WritePropertyList(writer, properties);
-            }
-            else
-            {
-                writer.Write((byte)0);
+                if (properties.Count > 0)
+                {
+                    writer.Write((byte)1);
+                    WritePropertyList(writer, properties);
+                }
+                else
+                {
+                    writer.Write((byte)0);
+                }
             }
             writer.WriteCompressedInt(data.Length);
             writer.Write(data);

--- a/MapleLib/WzLib/WzProperties/WzRawDataProperty.cs
+++ b/MapleLib/WzLib/WzProperties/WzRawDataProperty.cs
@@ -108,6 +108,12 @@ namespace MapleLib.WzLib.WzProperties
         {
             this._name = null;
             this._bytes = null;
+            foreach (WzImageProperty prop in properties)
+            {
+                prop.Dispose();
+            }
+            properties.Clear();
+            properties = null;
         }
         #endregion
 


### PR DESCRIPTION
**WzRawDataProperty**

* The `WriteValue` function lacks a type check during writing, which results in failure to parse when reopening the saved data.
* The `Dispose` function lacks handling for releasing `properties`.
