### PR TITLE
Don't attempt to delete files if resources aren't being freed

### DIFF
--- a/MapleLib/WzLib/Serializer/WzXmlDeserializer.cs
+++ b/MapleLib/WzLib/Serializer/WzXmlDeserializer.cs
@@ -118,7 +118,8 @@ namespace MapleLib.WzLib.Serializer
                 }
                 finally
                 {
-                    File.Delete(path);
+                    if (result.ParseEverything)
+                        File.Delete(path);
                 }
             }
             return result;


### PR DESCRIPTION
Fixes an error that can occur if the file is being opened for lazy loading which can cause import to fail due the file being in use when attempting to delete the file