### PR TITLE
Fix v229.2 WZ file parsing for 64-bit format

### DIFF
--- a/MapleLib/WzLib/WzDirectory.cs
+++ b/MapleLib/WzLib/WzDirectory.cs
@@ -198,7 +198,10 @@ namespace MapleLib.WzLib
                         {
                             int stringOffset = reader.ReadInt32();
                             rememberPos = reader.BaseStream.Position;
-                            reader.BaseStream.Position = reader.Header.FStart + stringOffset;
+
+                            // For 64-bit WZ files (no version header), the string offset needs +1 adjustment
+                            int extraOffset = (wzFile != null && wzFile.Is64BitWzFile) ? 1 : 0;
+                            reader.BaseStream.Position = reader.Header.FStart + stringOffset + extraOffset;
 
                             type = reader.ReadByte();
                             fname = reader.ReadString();

--- a/MapleLib/WzLib/WzFile.cs
+++ b/MapleLib/WzLib/WzFile.cs
@@ -382,6 +382,9 @@ namespace MapleLib.WzLib
 
                                     directory.ParseDirectory(lazyParse);
                                     this.wzDir = testDirectory;
+
+                                    Console.WriteLine("[WzFile] Accepted version {0} (hash={1}) for {2}, checkByte=0x{3:X2}",
+                                        mapleStoryPatchVersion, versionHash, Name, checkByte);
                                     return true;
                                 }
                             case 0x30:
@@ -389,11 +392,8 @@ namespace MapleLib.WzLib
                             case 0xBC: // Map002.wz? KMST?
                             default:
                                 {
-                                    string printError = string.Format("[WzFile.cs] New Wz image header found. checkByte = {0}. File Name = {1}", checkByte, Name);
-
-                                    Helpers.ErrorLogger.Log(Helpers.ErrorLevel.MissingFeature,printError);
-                                    Debug.WriteLine(printError);
-                                    // log or something
+                                    // checkByte did not match known image headers (0x73, 0x1b)
+                                    // This version hash produces wrong offsets — reject and try next version
                                     break;
                                 }
                         }
@@ -404,7 +404,7 @@ namespace MapleLib.WzLib
                         reader.BaseStream.Position = fallbackOffsetPosition; // reset
                         return false;
                     }
-                    return true;
+                    return false;
                 }
                 else // if there's no image in the WZ file (new KMST Base.wz), test the directory instead
                 {


### PR DESCRIPTION
## Fix v229.2 WZ file parsing for 64-bit format

- **WzDirectory.cs**: Add +1 offset adjustment for type 2 directory entries when parsing 64-bit WZ files (no version header). Without this, the seek lands 1 byte too early, reading garbled type bytes and strings.

- **WzFile.cs**: Fix `TryDecodeWithWZVersionNumber` returning `true` when the image checkByte doesn't match valid headers (0x73/0x1b). The default switch case would break and fall through to `return true`, accepting a wrong version hash and leaving wzDir unset. Files appeared in the tree but couldn't be expanded. Changed to `return false` so the brute-force continues until a correct hash is found.