### PR TITLE
Fix byte reading/writing to use the correct size in SaveImage()

### DIFF
--- a/MapleLib/WzLib/Serializer/WzImgSerializer.cs
+++ b/MapleLib/WzLib/Serializer/WzImgSerializer.cs
@@ -79,9 +79,7 @@ namespace MapleLib.WzLib.Serializer
             {
                 using (WzBinaryWriter wzWriter = new WzBinaryWriter(stream, GetOutputIv(img)))
                 {
-                    img.SaveImage(wzWriter, true,
-                        forceReadFromData: true // update the pos of data relative to itself, instead of the wz
-                        );
+                    img.SaveImage(wzWriter);
                 }
             }
         }

--- a/MapleLib/WzLib/WzImage.cs
+++ b/MapleLib/WzLib/WzImage.cs
@@ -487,7 +487,7 @@ namespace MapleLib.WzLib
             {
                 long pos = reader.BaseStream.Position;
                 reader.BaseStream.Position = offset;
-                writer.Write(reader.ReadBytes((int)pos));
+                writer.Write(reader.ReadBytes((int)size));
 
                 reader.BaseStream.Position = pos; // reset
             }


### PR DESCRIPTION
I discovered this bug while exporting .img files from a .wz file, where the exported .img was either corrupted (with fewer bytes than expected) or excessively large (with more bytes than expected).

This issue occurs because the code reads and writes data based on the current position, rather than the actual image size.

While creating this PR, I realized I had been using my own build based on v7 for a long time. I tested v8 and v9, and both work fine. I then found that this bug had been [fixed](https://github.com/lastbattle/MapleLib/commit/347c185), but I think the fix was not entirely correct, so I just reverted it.

P.S. This bug has existed since the fork’s inception. [Original code from hadeutscher](https://github.com/hadeutscher/MapleLib/blob/76a2bd3435dca9f8f9acbc77c82b05c7f1595b07/WzLib/WzImage.cs#L321)